### PR TITLE
Allow to use comma character in password. See man mount.cifs(8)

### DIFF
--- a/cifs
+++ b/cifs
@@ -124,7 +124,8 @@ doMount() {
 		errorExit "cifs mount: mount directory is not an empty directory: '$mountPoint'"
 	fi
 
-	result=$(mount -t cifs "$networkPath" "$mountPoint" -o "username=$cifsUsername,password=$cifsPassword,$mountOptions" 2>&1)
+	export PASSWD="$cifsPassword"
+	result=$(mount -t cifs "$networkPath" "$mountPoint" -o "username=$cifsUsername,$mountOptions" 2>&1)
 	if [[ $? -ne 0 ]] ; then
 		errorExit "cifs mount: failed to mount the network path: $result"
 	fi


### PR DESCRIPTION
I found only this solution to allow comma in password.

man mount.cifs(8):
> Note that a password which contains the delimiter character (i.e. a comma ',') will fail to be
> parsed correctly on the command line. However, the same password defined in
> the PASSWD environment variable or via a credentials file (see below) or entered at the password prompt will be read correctly.