### PR TITLE
Add domain as optional secret to include for cifs mount.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ It should output a JSON string containing `"status": "Success"`. This command is
 Running
 -------
 
-The plugin takes the CIFS username and password from a [Kubernetes Secret][15]. To create the secret, you first have to convert your username and password to base64 encoding:
+The plugin takes the CIFS username, password, and optionally domain from a [Kubernetes Secret][15]. To create the secret, you first have to convert your username, domain, and password to base64 encoding:
 
 ```bash
 echo -n username | base64
 echo -n password | base64
+echo -n domain | base64 # optional
 ```
 
-Then, create a file `secret.yml` and use the ouput of the above commands as username and password:
+Then, create a file `secret.yml` and use the ouput of the above commands as username, domain, and password:
 
 ```yaml
 apiVersion: v1
@@ -63,6 +64,7 @@ type: fstab/cifs
 data:
   username: 'ZXhhbXBsZQ=='
   password: 'bXktc2VjcmV0LXBhc3N3b3Jk'
+  domain: 'ZG9tYWluLmNvbQ==' # optional
 ```
 
 Apply the secret:

--- a/cifs
+++ b/cifs
@@ -50,9 +50,13 @@ set -u
 # --------------------------------------------------------------------
 
 # Uncomment the following lines to see how this plugin is called:
-# echo >> /tmp/cifs.log
-# date >> /tmp/cifs.log
-# echo "$@" >> /tmp/cifs.log
+debug=false
+
+if [ "$debug" = true ] ; then
+	echo >> /tmp/cifs.log
+	date >> /tmp/cifs.log
+	echo "$@" >> /tmp/cifs.log
+fi
 
 init() {
 	assertBinaryInstalled mount.cifs cifs-utils
@@ -106,6 +110,34 @@ doMount() {
 	if [[ $? -ne 0 ]] ; then
 		errorExit "cifs mount: password not found. the flexVolume definition must contain a secretRef to a secret with username and password."
 	fi
+
+	if ! cifsDomainBase64="$(jq --raw-output -e '.["kubernetes.io/secret/domain"]' <<< "$json" 2>/dev/null)" ; then
+		errorExit "cifs mount: error retrieving domain from secret"
+	fi
+
+	if [[ -n "$cifsDomainBase64" ]] ; then
+		if [ "$debug" = true ] ; then
+			echo "cifsDomainBase64: $cifsDomainBase64" >> /tmp/cifs.log
+		fi
+
+		if ! cifsDomain="$(base64 --decode <<< "$cifsDomainBase64" 2>/dev/null)" ; then
+			errorExit "cifs mount: domain secret is not base64 encoded."
+		fi
+
+		if [ "$debug" = true ] ; then
+			echo "cifsDomain: $cifsDomain" >> /tmp/cifs.log
+			echo "mountOptions before adding domain: $mountOptions" >> /tmp/cifs.log
+		fi
+
+		if ! mountOptions="${mountOptions},domain=${cifsDomain}" ; then
+			errorExit "cifs mount: error appending domain to mountOptions"
+		fi 
+
+		if [ "$debug" = true ] ; then
+			echo "mountOptions: $mountOptions" >> /tmp/cifs.log
+		fi
+	fi
+
 	cifsUsername="$(base64 --decode <<< "$cifsUsernameBase64" 2>/dev/null)"
 	if [[ $? -ne 0 ]] ; then
 		errorExit "cifs mount: username secret is not base64 encoded."


### PR DESCRIPTION
add code to check for domain in secrets
add code to add domain to $mountOptions if domain in secrets
change debugging to use  bool variable instead of comments. This makes it easier to include debug logging through out the script.