### PR TITLE
Return success from unmount when no file system is mounted at the input path

### DIFF
--- a/cifs
+++ b/cifs
@@ -139,7 +139,8 @@ doUnmount() {
 	fi
 	mountPoint="$1"
 	if [[ $(mountpoint "$mountPoint") != *"is a mountpoint"* ]] ; then
-		errorExit "cifs unmount: no filesystem mounted under directory: '$mountPoint'"
+		echo '{ "status": "Success" }'
+		exit 0
 	fi
 	result=$(umount "$mountPoint" 2>&1)
 	if [[ $? -ne 0 ]] ; then


### PR DESCRIPTION
This pull request changes the unmount operation to return the success status if no file system is mounted at a specified mount point. It can happen that the file system was already unmounted by other means. The unmount operation then does not have any work to do and can return the success status to confirm that no file system is mounted at a given path.

For instance, a pod with a CIFS flexVolume can run on a node that gets forcefully powered off, then the user decides to delete the pod and later start the node again. In this scenario, when the node is started again, the volume reconciler attempts to unmount the CIFS volume that the pod previously used on the machine. However, since the volume is no longer mounted, the CIFS plugin in this case returned a failure from the unmount operation. The reconciler then considered the volume as still mounted and repeatedly tried unmounting it which the plugin continued reporting as failing.

The change matches what is done in Kubernetes flexVolume examples: [NFS](https://github.com/kubernetes/examples/blob/b80c9417ab5056ecea6961e5873db680b4295c83/staging/volumes/flexvolume/nfs#L68) and [LVM](https://github.com/kubernetes/examples/blob/b80c9417ab5056ecea6961e5873db680b4295c83/staging/volumes/flexvolume/lvm#L125).